### PR TITLE
Fix domainname of galley in envoy configmap istio-control/istio-discovery

### DIFF
--- a/istio-control/istio-discovery/templates/configmap-envoy.yaml
+++ b/istio-control/istio-discovery/templates/configmap-envoy.yaml
@@ -63,7 +63,7 @@ data:
 
         hosts:
           - socket_address:
-              address: istio-galley
+              address: istio-galley.{{ .Values.global.configNamespace }}
               port_value: 15019
 
 


### PR DESCRIPTION
Fixes the problem discussed in: https://github.com/istio-ecosystem/istio-installer/pull/2#discussion_r264734543

After debugging with tcpdump we saw that there are DNS queries for `istio-galley.istio-ingress.svc.cluster.local` et al. issued in the pilot pod. We fixed this in the configuration of envoy by appending the namespace variable.