### PR TITLE
Move MCP-address to mesh config (instead of using flag).

### DIFF
--- a/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-control/istio-discovery/templates/configmap.yaml
@@ -76,6 +76,14 @@ data:
     enableSdsTokenMount: true
     {{- end }}
 
+    {{- if .Values.useMCP }}
+    config_sources:
+    {{- if .Values.global.controlPlaneSecurityEnabled }}
+    - address: localhost:15019
+    {{- else }}
+    - address: istio-galley
+    {{- end }}
+    {{- end }}
     #
     defaultConfig:
       #

--- a/istio-control/istio-discovery/templates/deployment.yaml
+++ b/istio-control/istio-discovery/templates/deployment.yaml
@@ -53,13 +53,6 @@ spec:
           - "-a"
           - {{ .Release.Namespace }}
 {{- end }}
-{{- if .Values.useMCP }}
-{{- if .Values.global.controlPlaneSecurityEnabled }}
-          - --mcpServerAddrs=mcp://127.0.0.1:15019
-  {{ else }}
-          - --mcpServerAddrs=mcp://istio-galley
-{{- end }}
-{{- end }}
           - --secureGrpcAddr
           - ""
 {{- if .Values.global.trustDomain }}


### PR DESCRIPTION
The `--mcpServerAddrs` flag was deprecated for a while now and removed from master this morning (https://github.com/istio/istio/commit/612c138738446644d0db747604353e83f441e166).
In order for the installer to work with master, the value should be provided via the meshConfig.
This is also compatible with istio-1.1.