### PR TITLE
Fix istio repo location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ info:
 sync:
 ifneq ($(MOUNT), 1)
 	docker exec ${KIND_CLUSTER}-control-plane mkdir -p ${GOPATH}/src/github.com/istio-ecosystem/istio-installer \
-		${GOPATH}/src/github.com/istio.io
+		${GOPATH}/src/istio.io
 	docker cp . ${KIND_CLUSTER}-control-plane:${GOPATH}/src/github.com/istio-ecosystem/istio-installer
 	docker cp ${GOPATH}/src/istio.io/istio ${KIND_CLUSTER}-control-plane:${GOPATH}/src/istio.io
 	docker cp ${GOPATH}/src/istio.io/tools ${KIND_CLUSTER}-control-plane:${GOPATH}/src/istio.io


### PR DESCRIPTION
I have all my Istio stuff in `~/go/src/istio.io/...` not under a github.com folder. A quick grep of the Istio repo makes me think this is the standard. I suspect @costinm or others who made this have it in the github.com folder?

Also recommended in https://github.com/istio/istio/wiki/Dev-Guide

We need to either change this to match this, or we could try to make it smart