### PR TITLE
Add missing iop arguments to helm template again.

### DIFF
--- a/bin/iop
+++ b/bin/iop
@@ -43,7 +43,7 @@ function iop() {
 
     if [ "$1" == "-t" ]; then
         shift
-        render_kube_yaml $ns $rel $tmpl
+        render_kube_yaml $ns $rel $tmpl $*
     elif [ "$1" == "-d" ]; then
         shift
         kubectl delete --namespace $ns -l release=$ns-$rel $*
@@ -60,7 +60,7 @@ function iop() {
             kubectl label namespace $ns istio-env=$ISTIO_ENV --overwrite
         fi
 
-        render_kube_yaml $ns $rel $tmpl | kubectl apply -n $ns --prune -l release=$ns-$rel -f -
+        render_kube_yaml $ns $rel $tmpl $* | kubectl apply -n $ns --prune -l release=$ns-$rel -f -
     fi
 }
 


### PR DESCRIPTION
Co-authored-by: Ralf Pannemans <ralf.pannemans@sap.com>

This enables installing a istio-control  instance into a different namespace again, because the `--set global.configNamespace` flag (and other flags) had been discarded.