### PR TITLE
Delete old ns BEFORE restarting pods.

### DIFF
--- a/.concourse/concourse.yaml
+++ b/.concourse/concourse.yaml
@@ -279,7 +279,8 @@ jobs:
           - |
             echo "$KUBECONFIG" > /tmp/kubeconfig.yaml
             export KUBECONFIG=/tmp/kubeconfig.yaml
-            istio-installer/bin/install.sh switch_istio_control --update --remove-old-control
+            export REMOVE_OLD_CONTROL=true
+            istio-installer/bin/install.sh switch_istio_control --update
 
   - name: test-after-update
     serial_groups: [ cluster ]

--- a/.concourse/concourse.yaml
+++ b/.concourse/concourse.yaml
@@ -279,7 +279,7 @@ jobs:
           - |
             echo "$KUBECONFIG" > /tmp/kubeconfig.yaml
             export KUBECONFIG=/tmp/kubeconfig.yaml
-            istio-installer/bin/install.sh switch_istio_control --update
+            istio-installer/bin/install.sh switch_istio_control --update --remove-old-control
 
   - name: test-after-update
     serial_groups: [ cluster ]

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -95,8 +95,8 @@ function switch_istio_control() {
         for ns in $(kubectl get namespaces --no-headers -l istio-env=${ISTIO_CONTROL_OLD} -o=custom-columns=NAME:.metadata.name); do        kubectl label namespaces default --overwrite istio-env=${ISTIO_CONTROL_NS}
             kubectl label namespaces ${ns} --overwrite istio-env=${ISTIO_CONTROL_NS}
         done
-        kubectl set env --all deployment --env="LAST_MANUAL_RESTART=$(date +%s)" --namespace=default
         kubectl delete namespace $ISTIO_CONTROL_OLD --wait --ignore-not-found
+        kubectl set env --all deployment --env="LAST_MANUAL_RESTART=$(date +%s)" --namespace=default
     fi
 }
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -30,7 +30,7 @@ function install_crds() {
 # Cleanup all namespaces
 
 function cleanup() {
-    for namespace in istio-system  ${ISTIO_CONTROL_NS} istio-ingress istio-telemetry; do
+    for namespace in istio-system  ${ISTIO_CONTROL_NS} istio-control istio-control-master istio-ingress istio-telemetry; do
         kubectl delete namespace $namespace --wait --ignore-not-found
     done
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -109,16 +109,13 @@ COMMAND="install_all"
 METHOD=Install
 ISTIO_CONTROL_OLD=$(kubectl get namespaces -o=jsonpath='{$.items[:1].metadata.labels.istio-env}' -l istio-env)
 ISTIO_CONTROL_OLD=${ISTIO_CONTROL_OLD:-istio-control}
-REMOVE_OLD_CONTROL=false
+REMOVE_OLD_CONTROL=${REMOVE_OLD_CONTROL:-false}
 
 while [ $# -gt 0 ]
 do
     case "$1" in
         --update)
             METHOD=Update
-            ;;
-        --remove-old-control)
-            REMOVE_OLD_CONTROL=true
             ;;
         cleanup) COMMAND=$1 ;;
         install_crds) COMMAND=$1 ;;

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -60,6 +60,7 @@ BOOKINFO_DEPLOYMENTS="details-v1 productpage-v1 ratings-v1 reviews-v1 reviews-v2
 
 if [ "$SKIP_SETUP" -ne 1 ]; then
     kubectl create ns bookinfo || /bin/true
+    # We use the first namespace with sidecar injection enabled to determine the control plane's namespace.
     ISTIO_CONTROL=$(kubectl get namespaces -o=jsonpath='{$.items[:1].metadata.labels.istio-env}' -l istio-env)
     ISTIO_CONTROL=${ISTIO_CONTROL:-istio-control}
 

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -60,18 +60,15 @@ BOOKINFO_DEPLOYMENTS="details-v1 productpage-v1 ratings-v1 reviews-v1 reviews-v2
 
 if [ "$SKIP_SETUP" -ne 1 ]; then
     kubectl create ns bookinfo || /bin/true
-    kubectl label ns bookinfo istio-env=istio-control --overwrite
-    #kubectl delete -f samples/bookinfo/platform/kube/bookinfo.yaml --ignore-not-found
-    #kubectl delete -f samples/bookinfo/networking/destination-rule-all-mtls.yaml --ignore-not-found
-    #kubectl delete -f samples/bookinfo/networking/bookinfo-gateway.yaml --ignore-not-found
+    ISTIO_CONTROL=$(kubectl get namespaces -o=jsonpath='{$.items[:1].metadata.labels.istio-env}' -l istio-env)
+    ISTIO_CONTROL=${ISTIO_CONTROL:-istio-control}
+
+    kubectl label ns bookinfo istio-env=${ISTIO_CONTROL} --overwrite
 
     kubectl -n bookinfo apply -f samples/bookinfo/platform/kube/bookinfo.yaml
     kubectl -n bookinfo apply -f samples/bookinfo/networking/destination-rule-all-mtls.yaml
     kubectl -n bookinfo apply -f samples/bookinfo/networking/bookinfo-gateway.yaml
-    # Not sure what this does...
-    #for depl in ${BOOKINFO_DEPLOYMENTS}; do
-    #    kubectl patch deployment $depl --patch '{"spec": {"strategy": {"rollingUpdate": {"maxSurge": 1,"maxUnavailable": 0},"type": "RollingUpdate"}}}'
-    #done
+
     for depl in ${BOOKINFO_DEPLOYMENTS}; do
         kubectl -n bookinfo rollout status deployments $depl --timeout=$WAIT_TIMEOUT
     done


### PR DESCRIPTION
We switch istio-env to the new istio-control, first delete the old istio-control namespace before restarting pods. This prevents pods from using the old istio-control without us noticing.

Co-authored-by: Ralf Pannemans <ralf.pannemans@sap.com>