### PR TITLE
cleanup.sh: remove istio-env label from all namespaces

### DIFF
--- a/bin/cleanup.sh
+++ b/bin/cleanup.sh
@@ -4,3 +4,8 @@
 for namespace in istio-system istio-control istio-control-master istio-ingress istio-telemetry; do
     kubectl delete namespace $namespace --wait --ignore-not-found
 done
+
+ACTIVE_NAMESPACES=$(kubectl get namespaces --no-headers -l istio-env -o=custom-columns=NAME:.metadata.name)
+for ns in $ACTIVE_NAMESPACES; do
+    kubectl label namespaces ${ns} istio-env-
+done

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -66,7 +66,7 @@ if [ "$SKIP_SETUP" -ne 1 ]; then
     # We use the first namespace with sidecar injection enabled to determine the control plane's namespace.
     # Fails in KIND.
     if [ -z "$ISTIO_CONTROL" ]; then
-        ISTIO_CONTROL=$(kubectl get namespaces -o=jsonpath='{$.items[:1].metadata.labels.istio-env}' -l istio-env)
+        ISTIO_CONTROL=$(kubectl get namespaces -o=jsonpath='{$.items[:1].metadata.labels.istio-env}' -l istio-env || true )
     fi
     ISTIO_CONTROL=${ISTIO_CONTROL:-istio-control}
 


### PR DESCRIPTION
This makes the concourse pipeline more predictable as `install.sh` decides which namespace to use for `istio-control` based on `istio-env` labels of other namespaces (first in list).