### PR TITLE
Fix circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ jobs:
       - run:
           command: make sync
       - run:
-          command: make docker-run-test TEST_TARGET="install-crds install-ingress"
+          command: make docker-run-test TEST_TARGET="install-crds install-base install-ingress"
       - run:
           command: make docker-run-test TEST_TARGET="run-test.integration.kube.presubmit"
           # simple is currently failing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,17 +176,9 @@ jobs:
             git clone https://github.com/istio/istio.git $GOPATH/src/istio.io/istio
             git clone https://github.com/istio/tools.git $GOPATH/src/istio.io/tools
       - run:
-          # TODO: include in the istio base image
-          command: make ${GOPATH}/bin/kind
-      - run:
-          command: |
-            export PATH=/go/bin:$PATH
-            # Create KIND cluster (separate so we get time info)
-            make info dep prepare
+          command: make info dep
       - run:
           command: make sync
-      - run:
-          command: make docker-run-test TEST_TARGET="install-crds install-base install-ingress"
       - run:
           command: make docker-run-test TEST_TARGET="run-test.integration.kube.presubmit"
           # simple is currently failing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ jobs:
       - run:
           command: make sync
       - run:
-          command: make docker-run-test TEST_TARGET="install-ingress"
+          command: make docker-run-test TEST_TARGET="install-crds install-ingress"
       - run:
           command: make docker-run-test TEST_TARGET="run-test.integration.kube.presubmit"
           # simple is currently failing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,6 @@ workflows:
       - integration-presubmit-kind
       - integration-old-kind
       - install-minikube
-      - modular-installation
 
   all:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,9 +178,7 @@ jobs:
       - run:
           command: make info dep
       - run:
-          command: make sync
-      - run:
-          command: make docker-run-test TEST_TARGET="run-test.integration.kube.presubmit"
+          command: make run-test.integration.kube.presubmit
           # simple is currently failing
       - store_artifacts:
           path: /home/circleci/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,16 +170,9 @@ jobs:
             export PATH=/go/bin:$PATH
             WAIT_TIMEOUT=10m bin/install.sh
       - run:
-          command: |
-            mkdir -p $GOPATH/tmp
-            mkdir -p $GOPATH/src/istio.io/
-            git clone https://github.com/istio/istio.git $GOPATH/src/istio.io/istio
-            git clone https://github.com/istio/tools.git $GOPATH/src/istio.io/tools
-      - run:
           command: make info dep
       - run:
-          command: make run-test.integration.kube.presubmit
-          # simple is currently failing
+          command: make git.dep run-test.integration.kube.presubmit
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:


### PR DESCRIPTION
There where several problems:

- The `nightly` workflow referenced a non-existent job
- The `install-minikube` started a minikube cluster and installed istio, then started a kind cluster, installed istio and ran some tests inside the kind cluster.