### PR TITLE
fix: update mixer config to match istio/istio

### DIFF
--- a/istio-policy/templates/config.yaml
+++ b/istio-policy/templates/config.yaml
@@ -24,6 +24,10 @@ spec:
       valueType: STRING
     request.path:
       valueType: STRING
+    request.url_path:
+      valueType: STRING
+    request.query_params:
+      valueType: STRING_MAP
     request.reason:
       valueType: STRING
     request.referer:
@@ -86,6 +90,8 @@ spec:
       valueType: STRING
     context.protocol:
       valueType: STRING
+    context.proxy_error_code:
+      valueType: STRING
     context.timestamp:
       valueType: TIMESTAMP
     context.time:
@@ -121,7 +127,14 @@ spec:
       valueType: STRING
     rbac.permissive.effective_policy_id:
       valueType: STRING
-
+    check.error_code:
+      valueType: INT64
+    check.error_message:
+      valueType: STRING
+    check.cache_hit:
+      valueType: BOOL
+    quota.cache_hit:
+      valueType: BOOL
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: attributemanifest
@@ -129,9 +142,7 @@ metadata:
   name: kubernetes
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
+    app: istio-policy
     release: {{ .Release.Name }}
 spec:
   attributes:
@@ -146,8 +157,6 @@ spec:
     source.namespace:
       valueType: STRING
     source.owner:
-      valueType: STRING
-    source.service:  # DEPRECATED
       valueType: STRING
     source.serviceAccount:
       valueType: STRING
@@ -173,8 +182,6 @@ spec:
       valueType: STRING
     destination.namespace:
       valueType: STRING
-    destination.service: # DEPRECATED
-      valueType: STRING
     destination.service.uid:
       valueType: STRING
     destination.service.name:
@@ -192,358 +199,14 @@ spec:
     destination.workload.namespace:
       valueType: STRING
 ---
-apiVersion: "config.istio.io/v1alpha2"
-kind: handler
-metadata:
-  name: stdio
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  compiledAdapter: stdio
-  params:
-    outputAsJson: true
----
-apiVersion: "config.istio.io/v1alpha2"
-kind: logentry
-metadata:
-  name: accesslog
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  severity: '"Info"'
-  timestamp: request.time
-  variables:
-    sourceIp: source.ip | ip("0.0.0.0")
-    sourceApp: source.labels["app"] | ""
-    sourcePrincipal: source.principal | ""
-    sourceName: source.name | ""
-    sourceWorkload: source.workload.name | ""
-    sourceNamespace: source.namespace | ""
-    sourceOwner: source.owner | ""
-    destinationApp: destination.labels["app"] | ""
-    destinationIp: destination.ip | ip("0.0.0.0")
-    destinationServiceHost: destination.service.host | ""
-    destinationWorkload: destination.workload.name | ""
-    destinationName: destination.name | ""
-    destinationNamespace: destination.namespace | ""
-    destinationOwner: destination.owner | ""
-    destinationPrincipal: destination.principal | ""
-    apiClaims: request.auth.raw_claims | ""
-    apiKey: request.api_key | request.headers["x-api-key"] | ""
-    protocol: request.scheme | context.protocol | "http"
-    method: request.method | ""
-    url: request.path | ""
-    responseCode: response.code | 0
-    responseSize: response.size | 0
-    permissiveResponseCode: rbac.permissive.response_code | "none"
-    permissiveResponsePolicyID: rbac.permissive.effective_policy_id | "none"
-    requestSize: request.size | 0
-    requestId: request.headers["x-request-id"] | ""
-    clientTraceId: request.headers["x-client-trace-id"] | ""
-    latency: response.duration | "0ms"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-    requestedServerName: connection.requested_server_name | ""
-    userAgent: request.useragent | ""
-    responseTimestamp: response.time
-    receivedBytes: request.total_size | 0
-    sentBytes: response.total_size | 0
-    referer: request.referer | ""
-    httpAuthority: request.headers[":authority"] | request.host | ""
-    xForwardedFor: request.headers["x-forwarded-for"] | "0.0.0.0"
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    grpcStatus: response.grpc_status | ""
-    grpcMessage: response.grpc_message | ""
-  monitored_resource_type: '"global"'
----
-apiVersion: "config.istio.io/v1alpha2"
-kind: logentry
-metadata:
-  name: tcpaccesslog
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  severity: '"Info"'
-  timestamp: context.time | timestamp("2017-01-01T00:00:00Z")
-  variables:
-    connectionEvent: connection.event | ""
-    sourceIp: source.ip | ip("0.0.0.0")
-    sourceApp: source.labels["app"] | ""
-    sourcePrincipal: source.principal | ""
-    sourceName: source.name | ""
-    sourceWorkload: source.workload.name | ""
-    sourceNamespace: source.namespace | ""
-    sourceOwner: source.owner | ""
-    destinationApp: destination.labels["app"] | ""
-    destinationIp: destination.ip | ip("0.0.0.0")
-    destinationServiceHost: destination.service.host | ""
-    destinationWorkload: destination.workload.name | ""
-    destinationName: destination.name | ""
-    destinationNamespace: destination.namespace | ""
-    destinationOwner: destination.owner | ""
-    destinationPrincipal: destination.principal | ""
-    protocol: context.protocol | "tcp"
-    connectionDuration: connection.duration | "0ms"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-    requestedServerName: connection.requested_server_name | ""
-    receivedBytes: connection.received.bytes | 0
-    sentBytes: connection.sent.bytes | 0
-    totalReceivedBytes: connection.received.bytes_total | 0
-    totalSentBytes: connection.sent.bytes_total | 0
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-  monitored_resource_type: '"global"'
----
-apiVersion: "config.istio.io/v1alpha2"
-kind: rule
-metadata:
-  name: stdio
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  match: context.protocol == "http" || context.protocol == "grpc"
-  actions:
-  - handler: stdio
-    instances:
-    - accesslog.logentry
----
-apiVersion: "config.istio.io/v1alpha2"
-kind: rule
-metadata:
-  name: stdiotcp
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  match: context.protocol == "tcp"
-  actions:
-  - handler: stdio
-    instances:
-    - tcpaccesslog.logentry
----
-apiVersion: "config.istio.io/v1alpha2"
-kind: metric
-metadata:
-  name: requestcount
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  value: "1"
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.host | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    request_protocol: api.protocol | context.protocol | "unknown"
-    response_code: response.code | 200   
-    permissive_response_code: rbac.permissive.response_code | "none"
-    permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
----
-apiVersion: "config.istio.io/v1alpha2"
-kind: metric
-metadata:
-  name: requestduration
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  value: response.duration | "0ms"
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.host | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    request_protocol: api.protocol | context.protocol | "unknown"
-    response_code: response.code | 200
-    permissive_response_code: rbac.permissive.response_code | "none" 
-    permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
----
-apiVersion: "config.istio.io/v1alpha2"
-kind: metric
-metadata:
-  name: requestsize
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  value: request.size | 0
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.host | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    request_protocol: api.protocol | context.protocol | "unknown"
-    response_code: response.code | 200
-    permissive_response_code: rbac.permissive.response_code | "none" 
-    permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
----
-apiVersion: "config.istio.io/v1alpha2"
-kind: metric
-metadata:
-  name: responsesize
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  value: response.size | 0
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.host | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    request_protocol: api.protocol | context.protocol | "unknown"
-    response_code: response.code | 200
-    permissive_response_code: rbac.permissive.response_code | "none" 
-    permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
----
-apiVersion: "config.istio.io/v1alpha2"
-kind: metric
-metadata:
-  name: tcpbytesent
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  value: connection.sent.bytes | 0
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.name | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
----
-apiVersion: "config.istio.io/v1alpha2"
-kind: metric
-metadata:
-  name: tcpbytereceived
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  value: connection.received.bytes | 0
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.name | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
----
-
+{{- if .Values.adapters.kubernetesenv.enabled }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
   name: kubernetesenv
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
+    app: istio-policy
     release: {{ .Release.Name }}
 spec:
   compiledAdapter: kubernetesenv
@@ -562,15 +225,13 @@ metadata:
   name: kubeattrgenrulerule
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
+    app: istio-policy
     release: {{ .Release.Name }}
 spec:
   actions:
   - handler: kubernetesenv
     instances:
-    - attributes.kubernetes
+    - attributes
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -578,34 +239,32 @@ metadata:
   name: tcpkubeattrgenrulerule
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
+    app: istio-policy
     release: {{ .Release.Name }}
 spec:
   match: context.protocol == "tcp"
   actions:
   - handler: kubernetesenv
     instances:
-    - attributes.kubernetes
+    - attributes
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: kubernetes
+kind: instance
 metadata:
   name: attributes
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
+    app: istio-policy
     release: {{ .Release.Name }}
 spec:
-  # Pass the required attribute data to the adapter
-  source_uid: source.uid | ""
-  source_ip: source.ip | ip("0.0.0.0") # default to unspecified ip addr
-  destination_uid: destination.uid | ""
-  destination_port: destination.port | 0
-  attribute_bindings:
+  compiledTemplate: kubernetes
+  params:
+    # Pass the required attribute data to the adapter
+    source_uid: source.uid | ""
+    source_ip: source.ip | ip("0.0.0.0") # default to unspecified ip addr
+    destination_uid: destination.uid | ""
+    destination_port: destination.port | 0
+  attributeBindings:
     # Fill the new attributes from the adapter produced output.
     # $out refers to an instance of OutputTemplate message
     source.ip: $out.source_pod_ip | ip("0.0.0.0")
@@ -629,7 +288,7 @@ spec:
     destination.workload.uid: $out.destination_workload_uid | "unknown"
     destination.workload.name: $out.destination_workload_name | "unknown"
     destination.workload.namespace: $out.destination_workload_namespace | "unknown"
-
+{{- end }}
 ---
 # Configuration needed by Mixer.
 # Mixer cluster is delivered via CDS
@@ -658,29 +317,3 @@ spec:
       http:
         http2MaxRequests: 10000
         maxRequestsPerConnection: 10000
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: istio-telemetry
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  host: istio-telemetry.{{ .Release.Namespace }}.svc.cluster.local
-  trafficPolicy:
-    {{- if .Values.global.controlPlaneSecurityEnabled }}
-    portLevelSettings:
-    - port:
-        number: 15004
-      tls:
-        mode: ISTIO_MUTUAL
-    {{- end}}
-    connectionPool:
-      http:
-        http2MaxRequests: 10000
-        maxRequestsPerConnection: 10000
----

--- a/istio-policy/values.yaml
+++ b/istio-policy/values.yaml
@@ -12,4 +12,6 @@ cpu:
 
 podAnnotations: {}
 
-
+adapters:
+  kubernetesenv:
+    enabled: true

--- a/istio-telemetry/mixer-telemetry/templates/config.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/config.yaml
@@ -24,6 +24,10 @@ spec:
       valueType: STRING
     request.path:
       valueType: STRING
+    request.url_path:
+      valueType: STRING
+    request.query_params:
+      valueType: STRING_MAP
     request.reason:
       valueType: STRING
     request.referer:
@@ -86,6 +90,8 @@ spec:
       valueType: STRING
     context.protocol:
       valueType: STRING
+    context.proxy_error_code:
+      valueType: STRING
     context.timestamp:
       valueType: TIMESTAMP
     context.time:
@@ -121,6 +127,14 @@ spec:
       valueType: STRING
     rbac.permissive.effective_policy_id:
       valueType: STRING
+    check.error_code:
+      valueType: INT64
+    check.error_message:
+      valueType: STRING
+    check.cache_hit:
+      valueType: BOOL
+    quota.cache_hit:
+      valueType: BOOL
 
 ---
 apiVersion: "config.istio.io/v1alpha2"
@@ -144,8 +158,6 @@ spec:
     source.namespace:
       valueType: STRING
     source.owner:
-      valueType: STRING
-    source.service:  # DEPRECATED
       valueType: STRING
     source.serviceAccount:
       valueType: STRING
@@ -171,8 +183,6 @@ spec:
       valueType: STRING
     destination.namespace:
       valueType: STRING
-    destination.service: # DEPRECATED
-      valueType: STRING
     destination.service.uid:
       valueType: STRING
     destination.service.name:
@@ -190,7 +200,7 @@ spec:
     destination.workload.namespace:
       valueType: STRING
 ---
-{{- if .Values.stdioAccessLog }}
+{{- if .Values.adapters.stdio.enabled }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
@@ -202,11 +212,10 @@ metadata:
 spec:
   compiledAdapter: stdio
   params:
-    outputAsJson: false
-{{- end }}
+    outputAsJson: {{ .Values.adapters.stdio.outputAsJson }}
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: logentry
+kind: instance
 metadata:
   name: accesslog
   namespace: {{ .Release.Namespace }}
@@ -214,53 +223,56 @@ metadata:
     app: istio-telemetry
     release: {{ .Release.Name }}
 spec:
-  severity: '"Info"'
-  timestamp: request.time
-  variables:
-    sourceIp: source.ip | ip("0.0.0.0")
-    sourceApp: source.labels["app"] | ""
-    sourcePrincipal: source.principal | ""
-    sourceName: source.name | ""
-    sourceWorkload: source.workload.name | ""
-    sourceNamespace: source.namespace | ""
-    sourceOwner: source.owner | ""
-    destinationApp: destination.labels["app"] | ""
-    destinationIp: destination.ip | ip("0.0.0.0")
-    destinationServiceHost: destination.service.host | ""
-    destinationWorkload: destination.workload.name | ""
-    destinationName: destination.name | ""
-    destinationNamespace: destination.namespace | ""
-    destinationOwner: destination.owner | ""
-    destinationPrincipal: destination.principal | ""
-    apiClaims: request.auth.raw_claims | ""
-    apiKey: request.api_key | request.headers["x-api-key"] | ""
-    protocol: request.scheme | context.protocol | "http"
-    method: request.method | ""
-    url: request.path | ""
-    responseCode: response.code | 0
-    responseSize: response.size | 0
-    permissiveResponseCode: rbac.permissive.response_code | "none"
-    permissiveResponsePolicyID: rbac.permissive.effective_policy_id | "none"
-    requestSize: request.size | 0
-    requestId: request.headers["x-request-id"] | ""
-    clientTraceId: request.headers["x-client-trace-id"] | ""
-    latency: response.duration | "0ms"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-    requestedServerName: connection.requested_server_name | ""
-    userAgent: request.useragent | ""
-    responseTimestamp: response.time
-    receivedBytes: request.total_size | 0
-    sentBytes: response.total_size | 0
-    referer: request.referer | ""
-    httpAuthority: request.headers[":authority"] | request.host | ""
-    xForwardedFor: request.headers["x-forwarded-for"] | "0.0.0.0"
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    grpcStatus: response.grpc_status | ""
-    grpcMessage: response.grpc_message | ""
-  monitored_resource_type: '"global"'
+  compiledTemplate: logentry
+  params:
+    severity: '"Info"'
+    timestamp: request.time
+    variables:
+      sourceIp: source.ip | ip("0.0.0.0")
+      sourceApp: source.labels["app"] | ""
+      sourcePrincipal: source.principal | ""
+      sourceName: source.name | ""
+      sourceWorkload: source.workload.name | ""
+      sourceNamespace: source.namespace | ""
+      sourceOwner: source.owner | ""
+      destinationApp: destination.labels["app"] | ""
+      destinationIp: destination.ip | ip("0.0.0.0")
+      destinationServiceHost: destination.service.host | ""
+      destinationWorkload: destination.workload.name | ""
+      destinationName: destination.name | ""
+      destinationNamespace: destination.namespace | ""
+      destinationOwner: destination.owner | ""
+      destinationPrincipal: destination.principal | ""
+      apiClaims: request.auth.raw_claims | ""
+      apiKey: request.api_key | request.headers["x-api-key"] | ""
+      protocol: request.scheme | context.protocol | "http"
+      method: request.method | ""
+      url: request.path | ""
+      responseCode: response.code | 0
+      responseFlags: context.proxy_error_code | ""
+      responseSize: response.size | 0
+      permissiveResponseCode: rbac.permissive.response_code | "none"
+      permissiveResponsePolicyID: rbac.permissive.effective_policy_id | "none"
+      requestSize: request.size | 0
+      requestId: request.headers["x-request-id"] | ""
+      clientTraceId: request.headers["x-client-trace-id"] | ""
+      latency: response.duration | "0ms"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      requestedServerName: connection.requested_server_name | ""
+      userAgent: request.useragent | ""
+      responseTimestamp: response.time
+      receivedBytes: request.total_size | 0
+      sentBytes: response.total_size | 0
+      referer: request.referer | ""
+      httpAuthority: request.headers[":authority"] | request.host | ""
+      xForwardedFor: request.headers["x-forwarded-for"] | "0.0.0.0"
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      grpcStatus: response.grpc_status | ""
+      grpcMessage: response.grpc_message | ""
+    monitored_resource_type: '"global"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: logentry
+kind: instance
 metadata:
   name: tcpaccesslog
   namespace: {{ .Release.Namespace }}
@@ -268,37 +280,39 @@ metadata:
     app: istio-telemetry
     release: {{ .Release.Name }}
 spec:
-  severity: '"Info"'
-  timestamp: context.time | timestamp("2017-01-01T00:00:00Z")
-  variables:
-    connectionEvent: connection.event | ""
-    sourceIp: source.ip | ip("0.0.0.0")
-    sourceApp: source.labels["app"] | ""
-    sourcePrincipal: source.principal | ""
-    sourceName: source.name | ""
-    sourceWorkload: source.workload.name | ""
-    sourceNamespace: source.namespace | ""
-    sourceOwner: source.owner | ""
-    destinationApp: destination.labels["app"] | ""
-    destinationIp: destination.ip | ip("0.0.0.0")
-    destinationServiceHost: destination.service.host | ""
-    destinationWorkload: destination.workload.name | ""
-    destinationName: destination.name | ""
-    destinationNamespace: destination.namespace | ""
-    destinationOwner: destination.owner | ""
-    destinationPrincipal: destination.principal | ""
-    protocol: context.protocol | "tcp"
-    connectionDuration: connection.duration | "0ms"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-    requestedServerName: connection.requested_server_name | ""
-    receivedBytes: connection.received.bytes | 0
-    sentBytes: connection.sent.bytes | 0
-    totalReceivedBytes: connection.received.bytes_total | 0
-    totalSentBytes: connection.sent.bytes_total | 0
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-  monitored_resource_type: '"global"'
+  compiledTemplate: logentry
+  params:
+    severity: '"Info"'
+    timestamp: context.time | timestamp("2017-01-01T00:00:00Z")
+    variables:
+      connectionEvent: connection.event | ""
+      sourceIp: source.ip | ip("0.0.0.0")
+      sourceApp: source.labels["app"] | ""
+      sourcePrincipal: source.principal | ""
+      sourceName: source.name | ""
+      sourceWorkload: source.workload.name | ""
+      sourceNamespace: source.namespace | ""
+      sourceOwner: source.owner | ""
+      destinationApp: destination.labels["app"] | ""
+      destinationIp: destination.ip | ip("0.0.0.0")
+      destinationServiceHost: destination.service.host | ""
+      destinationWorkload: destination.workload.name | ""
+      destinationName: destination.name | ""
+      destinationNamespace: destination.namespace | ""
+      destinationOwner: destination.owner | ""
+      destinationPrincipal: destination.principal | ""
+      protocol: context.protocol | "tcp"
+      connectionDuration: connection.duration | "0ms"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      requestedServerName: connection.requested_server_name | ""
+      receivedBytes: connection.received.bytes | 0
+      sentBytes: connection.sent.bytes | 0
+      totalReceivedBytes: connection.received.bytes_total | 0
+      totalSentBytes: connection.sent.bytes_total | 0
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      responseFlags: context.proxy_error_code | ""
+    monitored_resource_type: '"global"'
 ---
-{{- if .Values.stdioAccessLog }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
@@ -312,7 +326,7 @@ spec:
   actions:
   - handler: stdio
     instances:
-    - accesslog.logentry
+    - accesslog
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -327,11 +341,12 @@ spec:
   actions:
   - handler: stdio
     instances:
-    - tcpaccesslog.logentry
+    - tcpaccesslog
 {{- end }}
 ---
+{{- if .Values.adapters.prometheus.enabled }}
 apiVersion: "config.istio.io/v1alpha2"
-kind: metric
+kind: instance
 metadata:
   name: requestcount
   namespace: {{ .Release.Namespace }}
@@ -339,31 +354,34 @@ metadata:
     app: istio-telemetry
     release: {{ .Release.Name }}
 spec:
-  value: "1"
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.host | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    request_protocol: api.protocol | context.protocol | "unknown"
-    response_code: response.code | 200   
-    permissive_response_code: rbac.permissive.response_code | "none"
-    permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
+  compiledTemplate: metric
+  params:
+    value: "1"
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      request_protocol: api.protocol | context.protocol | "unknown"
+      response_code: response.code | 200
+      response_flags: context.proxy_error_code | "-"
+      permissive_response_code: rbac.permissive.response_code | "none"
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+    monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: metric
+kind: instance
 metadata:
   name: requestduration
   namespace: {{ .Release.Namespace }}
@@ -371,31 +389,34 @@ metadata:
     app: istio-telemetry
     release: {{ .Release.Name }}
 spec:
-  value: response.duration | "0ms"
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.host | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    request_protocol: api.protocol | context.protocol | "unknown"
-    response_code: response.code | 200
-    permissive_response_code: rbac.permissive.response_code | "none" 
-    permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
+  compiledTemplate: metric
+  params:
+    value: response.duration | "0ms"
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      request_protocol: api.protocol | context.protocol | "unknown"
+      response_code: response.code | 200
+      response_flags: context.proxy_error_code | "-"
+      permissive_response_code: rbac.permissive.response_code | "none" 
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+    monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: metric
+kind: instance
 metadata:
   name: requestsize
   namespace: {{ .Release.Namespace }}
@@ -403,122 +424,190 @@ metadata:
     app: istio-telemetry
     release: {{ .Release.Name }}
 spec:
-  value: request.size | 0
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.host | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    request_protocol: api.protocol | context.protocol | "unknown"
-    response_code: response.code | 200
-    permissive_response_code: rbac.permissive.response_code | "none" 
-    permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
+  compiledTemplate: metric
+  params:
+    value: request.size | 0
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      request_protocol: api.protocol | context.protocol | "unknown"
+      response_code: response.code | 200
+      response_flags: context.proxy_error_code | "-"
+      permissive_response_code: rbac.permissive.response_code | "none" 
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+    monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: metric
+kind: instance
 metadata:
   name: responsesize
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-telemetry
-    chart: istio-telemetry
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  value: response.size | 0
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.host | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    request_protocol: api.protocol | context.protocol | "unknown"
-    response_code: response.code | 200
-    permissive_response_code: rbac.permissive.response_code | "none" 
-    permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
+  compiledTemplate: metric
+  params:
+    value: response.size | 0
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      request_protocol: api.protocol | context.protocol | "unknown"
+      response_code: response.code | 200
+      response_flags: context.proxy_error_code | "-"
+      permissive_response_code: rbac.permissive.response_code | "none" 
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+    monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: metric
+kind: instance
 metadata:
   name: tcpbytesent
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-telemetry
-    chart: istio-telemetry
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  value: connection.sent.bytes | 0
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.name | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
+  compiledTemplate: metric
+  params:
+    value: connection.sent.bytes | 0
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      response_flags: context.proxy_error_code | "-"
+    monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: metric
+kind: instance
 metadata:
   name: tcpbytereceived
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-telemetry
-    chart: istio-telemetry
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  value: connection.received.bytes | 0
-  dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-    source_workload: source.workload.name | "unknown"
-    source_workload_namespace: source.workload.namespace | "unknown"
-    source_principal: source.principal | "unknown"
-    source_app: source.labels["app"] | "unknown"
-    source_version: source.labels["version"] | "unknown"
-    destination_workload: destination.workload.name | "unknown"
-    destination_workload_namespace: destination.workload.namespace | "unknown"
-    destination_principal: destination.principal | "unknown"
-    destination_app: destination.labels["app"] | "unknown"
-    destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.name | "unknown"
-    destination_service_name: destination.service.name | "unknown"
-    destination_service_namespace: destination.service.namespace | "unknown"
-    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-  monitored_resource_type: '"UNSPECIFIED"'
+  compiledTemplate: metric
+  params:
+    value: connection.received.bytes | 0
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      response_flags: context.proxy_error_code | "-"
+    monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: tcpconnectionsopened
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-telemetry
+    release: {{ .Release.Name }}
+spec:
+  compiledTemplate: metric
+  params:
+    value: "1"
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.name | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      response_flags: context.proxy_error_code | "-"
+    monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: tcpconnectionsclosed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-telemetry
+    release: {{ .Release.Name }}
+spec:
+  compiledTemplate: metric
+  params:
+    value: "1"
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.name | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      response_flags: context.proxy_error_code | "-"
+    monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: handler
@@ -527,8 +616,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-telemetry
-    chart: istio-telemetry
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
   compiledAdapter: prometheus
@@ -537,7 +624,7 @@ spec:
       metricsExpiryDuration: "{{ .Values.adapters.prometheus.metricsExpiryDuration }}"
     metrics:
     - name: requests_total
-      instance_name: requestcount.metric.{{ .Release.Namespace }}
+      instance_name: requestcount.instance.{{ .Release.Namespace }}
       kind: COUNTER
       label_names:
       - reporter
@@ -556,11 +643,12 @@ spec:
       - destination_service_namespace
       - request_protocol
       - response_code
+      - response_flags
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
     - name: request_duration_seconds
-      instance_name: requestduration.metric.{{ .Release.Namespace }}
+      instance_name: requestduration.instance.{{ .Release.Namespace }}
       kind: DISTRIBUTION
       label_names:
       - reporter
@@ -579,6 +667,7 @@ spec:
       - destination_service_namespace
       - request_protocol
       - response_code
+      - response_flags
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
@@ -586,7 +675,7 @@ spec:
         explicit_buckets:
           bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
     - name: request_bytes
-      instance_name: requestsize.metric.{{ .Release.Namespace }}
+      instance_name: requestsize.instance.{{ .Release.Namespace }}
       kind: DISTRIBUTION
       label_names:
       - reporter
@@ -605,6 +694,7 @@ spec:
       - destination_service_namespace
       - request_protocol
       - response_code
+      - response_flags
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
@@ -614,7 +704,7 @@ spec:
           scale: 1
           growthFactor: 10
     - name: response_bytes
-      instance_name: responsesize.metric.{{ .Release.Namespace }}
+      instance_name: responsesize.instance.{{ .Release.Namespace }}
       kind: DISTRIBUTION
       label_names:
       - reporter
@@ -633,6 +723,7 @@ spec:
       - destination_service_namespace
       - request_protocol
       - response_code
+      - response_flags
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
@@ -642,7 +733,7 @@ spec:
           scale: 1
           growthFactor: 10
     - name: tcp_sent_bytes_total
-      instance_name: tcpbytesent.metric.{{ .Release.Namespace }}
+      instance_name: tcpbytesent.instance.{{ .Release.Namespace }}
       kind: COUNTER
       label_names:
       - reporter
@@ -660,8 +751,9 @@ spec:
       - destination_service_name
       - destination_service_namespace
       - connection_security_policy
+      - response_flags
     - name: tcp_received_bytes_total
-      instance_name: tcpbytereceived.metric.{{ .Release.Namespace }}
+      instance_name: tcpbytereceived.instance.{{ .Release.Namespace }}
       kind: COUNTER
       label_names:
       - reporter
@@ -679,6 +771,47 @@ spec:
       - destination_service_name
       - destination_service_namespace
       - connection_security_policy
+      - response_flags
+    - name: tcp_connections_opened_total
+      instance_name: tcpconnectionsopened.instance.{{ .Release.Namespace }}
+      kind: COUNTER
+      label_names:
+      - reporter
+      - source_app
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - connection_security_policy
+      - response_flags
+    - name: tcp_connections_closed_total
+      instance_name: tcpconnectionsclosed.instance.{{ .Release.Namespace }}
+      kind: COUNTER
+      label_names:
+      - reporter
+      - source_app
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - connection_security_policy
+      - response_flags
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -687,18 +820,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-telemetry
-    chart: istio-telemetry
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  match: context.protocol == "http" || context.protocol == "grpc"
+  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false) && (match((request.useragent | "-"), "Prometheus*") == false)
   actions:
   - handler: prometheus
     instances:
-    - requestcount.metric
-    - requestduration.metric
-    - requestsize.metric
-    - responsesize.metric
+    - requestcount
+    - requestduration
+    - requestsize
+    - responsesize
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -707,18 +838,47 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-telemetry
-    chart: istio-telemetry
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
   match: context.protocol == "tcp"
   actions:
   - handler: prometheus
     instances:
-    - tcpbytesent.metric
-    - tcpbytereceived.metric
+    - tcpbytesent
+    - tcpbytereceived
 ---
-
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: promtcpconnectionopen
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-telemetry
+    release: {{ .Release.Name }}
+spec:
+  match: context.protocol == "tcp" && ((connection.event | "na") == "open")
+  actions:
+  - handler: prometheus
+    instances:
+    - tcpconnectionsopened
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: promtcpconnectionclosed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-telemetry
+    release: {{ .Release.Name }}
+spec:
+  match: context.protocol == "tcp" && ((connection.event | "na") == "close")
+  actions:
+  - handler: prometheus
+    instances:
+    - tcpconnectionsclosed
+{{- end }}
+---
+{{- if .Values.adapters.kubernetesenv.enabled }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
@@ -726,8 +886,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-telemetry
-    chart: istio-telemetry
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
   compiledAdapter: kubernetesenv
@@ -747,14 +905,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-telemetry
-    chart: istio-telemetry
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
   actions:
   - handler: kubernetesenv
     instances:
-    - attributes.kubernetes
+    - attributes
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -763,33 +919,33 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-telemetry
-    chart: istio-telemetry
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
   match: context.protocol == "tcp"
   actions:
   - handler: kubernetesenv
     instances:
-    - attributes.kubernetes
+    - attributes
 ---
 apiVersion: "config.istio.io/v1alpha2"
-kind: kubernetes
+kind: instance
 metadata:
   name: attributes
   namespace: {{ .Release.Namespace }}
   labels:
-    app: istio-telemetry
-    chart: istio-telemetry
+    app: {{ template "mixer.name" . }}
+    chart: {{ template "mixer.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  # Pass the required attribute data to the adapter
-  source_uid: source.uid | ""
-  source_ip: source.ip | ip("0.0.0.0") # default to unspecified ip addr
-  destination_uid: destination.uid | ""
-  destination_port: destination.port | 0
-  attribute_bindings:
+  compiledTemplate: kubernetes
+  params:
+    # Pass the required attribute data to the adapter
+    source_uid: source.uid | ""
+    source_ip: source.ip | ip("0.0.0.0") # default to unspecified ip addr
+    destination_uid: destination.uid | ""
+    destination_port: destination.port | 0
+  attributeBindings:
     # Fill the new attributes from the adapter produced output.
     # $out refers to an instance of OutputTemplate message
     source.ip: $out.source_pod_ip | ip("0.0.0.0")
@@ -813,35 +969,7 @@ spec:
     destination.workload.uid: $out.destination_workload_uid | "unknown"
     destination.workload.name: $out.destination_workload_name | "unknown"
     destination.workload.namespace: $out.destination_workload_namespace | "unknown"
-
----
-# Configuration needed by Mixer.
-# Mixer cluster is delivered via CDS
-# Specify mixer cluster settings
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: istio-policy
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: istio-telemetry
-    chart: istio-telemetry
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-spec:
-  host: istio-policy.{{ .Release.Namespace }}.svc.cluster.local
-  trafficPolicy:
-    {{- if .Values.global.controlPlaneSecurityEnabled }}
-    portLevelSettings:
-    - port:
-        number: 15004
-      tls:
-        mode: ISTIO_MUTUAL
-    {{- end}}
-    connectionPool:
-      http:
-        http2MaxRequests: 10000
-        maxRequestsPerConnection: 10000
+{{- end }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule

--- a/istio-telemetry/mixer-telemetry/values.yaml
+++ b/istio-telemetry/mixer-telemetry/values.yaml
@@ -1,7 +1,3 @@
-# If set to true, will add 'rule' and 'stdio' handler for access logs.
-# If false, user will need to configure their own rules outside of installer.
-stdioAccessLog: false
-
 image: mixer
 env:
   GODEBUG: gctrace=2
@@ -21,6 +17,19 @@ resources:
 podAnnotations: {}
 
 adapters:
+  # stdio is a debug adapter in istio-telemetry, it is not recommended for production use.
+  stdio:
+    # If set to true, will add 'rule' and 'stdio' handler for access logs.
+    # If false, user will need to configure their own rules outside of installer.
+    enabled: false
+    outputAsJson: false
+
   prometheus:
+    enabled: true
     metricsExpiryDuration: 10m
 
+  kubernetesenv:
+    enabled: true
+
+  # Setting this to false sets the useAdapterCRDs mixer startup argument to false
+  useAdapterCRDs: false


### PR DESCRIPTION
There were a large number of diffs around mixer config in the `mixer-telemetry` and `istio-policy` directories. This PR attempts to correct those issues.

In particular, this PR:
- updates the attribute manifests to match 1.1.x
- removes telemetry-related config from policy
- updates CRs to use the new-style config (only instances, handlers, rules)
- adds adapter config guards based on install options.

Helps to address #67.