### PR TITLE
fix(mixer-telemetry): remove bad template refs

### DIFF
--- a/istio-telemetry/mixer-telemetry/templates/config.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/config.yaml
@@ -933,9 +933,7 @@ metadata:
   name: attributes
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "mixer.name" . }}
-    chart: {{ template "mixer.chart" . }}
-    heritage: {{ .Release.Service }}
+    app: istio-telemetry
     release: {{ .Release.Name }}
 spec:
   compiledTemplate: kubernetes
@@ -978,8 +976,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-telemetry
-    chart: istio-telemetry
-    heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
   host: istio-telemetry.{{ .Release.Namespace }}.svc.cluster.local


### PR DESCRIPTION
Missed a few bits in #70 ; this corrects those issues.