### PR TITLE
Set pipeline to master

### DIFF
--- a/.concourse/concourse.yaml
+++ b/.concourse/concourse.yaml
@@ -8,7 +8,7 @@ resources:
     type: time
     source: {interval: 24h}
 
-  - name: istio-installer
+  - name: istio-installer #DO NOT SET TO FORK - for testing use another pipeline and pause this one
     type: git
     source:
       uri: "https://github.com/istio-ecosystem/istio-installer"
@@ -26,6 +26,24 @@ jobs:
       trigger: true
     - get: istio-installer
       trigger: true
+  
+    - task: log-used-repo
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: gcr.io/peripli/istio-base
+        inputs:
+          - name: istio-installer
+        run:
+          path: /bin/sh
+          args:
+          - -ecx
+          - |
+            cd istio-installer
+            git remote -v
+            git branch
 
     - task: install-1-1-daily
       params: &params-1-1-daily

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -24,7 +24,7 @@ function print_help() {
 # Customizable
 INGRESS_NS=${INGRESS_NS:-istio-ingress}
 
-export WAIT_TIMEOUT=${WAIT_TIMEOUT:-5m}
+export WAIT_TIMEOUT=${WAIT_TIMEOUT:-3m}
 SKIP_CLEANUP=${SKIP_CLEANUP:-0}
 SKIP_SETUP=${SKIP_SETUP:-0}
 while [ $# -gt 0 ]


### PR DESCRIPTION
For testing purposes, the pipeline was set to a branch meaning that the status was not the actual status of master.